### PR TITLE
Corrected variable name have_sslnodict to sasl_sslnodict in entrypoint script

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -291,7 +291,7 @@ ssl-require-client-authentication=yes
 EOS
                 fi
 
-                if [ $sasl_sslnodict -eq "1" ]; then
+                if [ $have_sslnodict -eq "1" ]; then
                     cat >> $QPIDD_CONFIG_FILE <<-EOS
 ssl-sasl-no-dict=yes
 EOS


### PR DESCRIPTION
entrypoint script sets variable have_sslnodict, but later on uses $sasl_sslnodict in an if statement. This made starting a container with provided ssl server private and key to print this error:

/docker-entrypoint.sh: line 294: [: -eq: unary operator expected
